### PR TITLE
feat: 新增Python 3.13兼容性支持

### DIFF
--- a/README-en_US.md
+++ b/README-en_US.md
@@ -6,7 +6,7 @@ Contains a series of tool functions/classes designed to enhance the development 
 
 <div>
 
-[![Pyhton](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](./setup.py)
+[![Pyhton](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](./setup.py)
 [![GitHub](https://shields.io/badge/license-MIT-informational)](https://github.com/CNFeffery/feffery-antd-components/blob/master/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/feffery-dash-utils.svg?color=dark-green)](https://pypi.org/project/feffery-dash-utils/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <div>
 
-[![Pyhton](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](./setup.py)
+[![Pyhton](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](./setup.py)
 [![GitHub](https://shields.io/badge/license-MIT-informational)](https://github.com/CNFeffery/feffery-antd-components/blob/master/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/feffery-dash-utils.svg?color=dark-green)](https://pypi.org/project/feffery-dash-utils/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/feffery_dash_utils/style_utils/style.py
+++ b/feffery_dash_utils/style_utils/style.py
@@ -462,10 +462,15 @@ def style(
         - zIndex: 设置定位元素的堆叠顺序。  Sets the stack order of a positioned element
 """
 
-    _, _, _, args = inspect.getargvalues(inspect.currentframe())
-    kwargs = args.pop('kwargs')
-    # 去除None值属性
-    args = {key: value for key, value in args.items() if value is not None and key not in ['rawCSS']}
+    frame = inspect.currentframe()
+    try:
+        argvalues = inspect.getargvalues(frame)
+        args_dict = dict(argvalues.locals)
+        kwargs = args_dict.pop('kwargs', {})
+        # 去除None值属性
+        args = {key: value for key, value in args_dict.items() if value is not None and key not in ['rawCSS', 'frame', 'argvalues', 'args_dict']}
+    finally:
+        del frame
 
     # 处理针对rawCSS的自动解析
     args_from_css = {}

--- a/scripts/generate_style.py
+++ b/scripts/generate_style.py
@@ -63,7 +63,7 @@ styles = {
     for key in (
         set(zh_cn_styles.keys()) & set(en_us_styles.keys())
     )
-    if re.match('[\-a-z]+', key)
+    if re.match(r'[\-a-z]+', key)
 }
 
 # 生成style_utils.py文件
@@ -82,10 +82,15 @@ def style(
 <函数参数说明>
 """
 
-    _, _, _, args = inspect.getargvalues(inspect.currentframe())
-    kwargs = args.pop('kwargs')
-    # 去除None值属性
-    args = {key: value for key, value in args.items() if value is not None and key not in ['rawCSS']}
+    frame = inspect.currentframe()
+    try:
+        argvalues = inspect.getargvalues(frame)
+        args_dict = dict(argvalues.locals)
+        kwargs = args_dict.pop('kwargs', {})
+        # 去除None值属性
+        args = {key: value for key, value in args_dict.items() if value is not None and key not in ['rawCSS', 'frame', 'argvalues', 'args_dict']}
+    finally:
+        del frame
 
     # 处理针对rawCSS的自动解析
     args_from_css = {}

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         'Framework :: Dash',
     ],
     url='https://github.com/CNFeffery/feffery-dash-utils',
-    python_requires=">=3.8, <3.13",
+    python_requires=">=3.8",
     install_requires=['cssutils', 'packaging'],
 )


### PR DESCRIPTION

- 修复scripts/generate_style.py中的正则表达式转义警告
- 修复inspect.getargvalues()在Python 3.13下的兼容性问题
- 移除setup.py中Python版本上限限制（原为<3.13）
- 所有模块在Python 3.13.4下测试通过

修改文件:
- scripts/generate_style.py: 修复正则和inspect兼容性
- setup.py: 更新python_requires以支持Python 3.13+
- feffery_dash_utils/style_utils/style.py: 使用修复后的脚本重新生成

**关联 Issue：** #4 